### PR TITLE
Moved LAContext inside methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Allow users to authenticate with Face ID or Touch ID on iOS devices
 
 ![Logo](https://www.intego.com/mac-security-blog/wp-content/uploads/2017/10/Touch-ID-vs-Face-ID.png)
 
-## Instalation
+## Installation
 
 ```sh
 npm install capacitor-face-id

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ FaceId.isAvailable().then(checkResult => {
 
 | Method                            | Default                                             | Type                          | Description                                |
 | --------------------------------- | --------------------------------------------------- | ----------------------------- | ------------------------------------------ |
-| isAvailable()                     |                                                     | `Promise<{ value: boolean }>` | Checks if Face ID or Touch ID is available |
+| isAvailable()                     |                                                     | `Promise<{ value: string }>`  | Checks if Face ID or Touch ID is available |
 | auth(options?: {reason?: string}) | options: {reason: "Access requires authentication"} | `Promise<void>`               | Displays the Face ID or Touch ID screen    |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ FaceId.isAvailable().then(checkResult => {
 
 ## API
 
-| Method                            | Default                                             | Type                          | Description                                |
-| --------------------------------- | --------------------------------------------------- | ----------------------------- | ------------------------------------------ |
-| isAvailable()                     |                                                     | `Promise<{ value: string }>`  | Checks if Face ID or Touch ID is available |
-| auth(options?: {reason?: string}) | options: {reason: "Access requires authentication"} | `Promise<void>`               | Displays the Face ID or Touch ID screen    |
+| Method                            | Default                                             | Type                         | Description                                                         |
+| --------------------------------- | --------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------- |
+| isAvailable()                     |                                                     | `Promise<{ value: string }>` | Checks if Face ID or Touch ID is available, and returns type if so. |
+| auth(options?: {reason?: string}) | options: {reason: "Access requires authentication"} | `Promise<void>`              | Displays the Face ID or Touch ID screen                             |

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -16,20 +16,20 @@ public class FaceId: CAPPlugin {
             switch(authContext.biometryType) {
             case .none:
                 call.success([
-                    "value": 'None'
+                    "value": "None"
                 ])
             case .touchID:
                 call.success([
-                    "value": 'TouchId'
+                    "value": "TouchId"
                 ])
             case .faceID:
                 call.success([
-                    "value": 'FaceId'
+                    "value": "FaceId"
                 ])
             }
         } else {
             call.success([
-                "value": 'None'
+                "value": "None"
             ])
         }
     }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -8,10 +8,11 @@ import LocalAuthentication
  */
 @objc(FaceId)
 public class FaceId: CAPPlugin {
-    let authContext = LAContext()
     
     @objc func isAvailable(_ call: CAPPluginCall) {
         if #available(iOS 11, *) {
+            let authContext = LAContext()
+            
             let _ = authContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
             switch(authContext.biometryType) {
             case .none:
@@ -35,6 +36,10 @@ public class FaceId: CAPPlugin {
     }
     
     @objc func auth(_ call: CAPPluginCall) {
+        let authContext = LAContext()
+        
+        authContext.touchIDAuthenticationAllowableReuseDuration = 60;
+        
         let reason = call.getString("reason") ?? "Access requires authentication"
         authContext.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason ) { success, error in
             if success {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -16,20 +16,20 @@ public class FaceId: CAPPlugin {
             switch(authContext.biometryType) {
             case .none:
                 call.success([
-                    "value": false
+                    "value": 'None'
                 ])
             case .touchID:
                 call.success([
-                    "value": true
+                    "value": 'TouchId'
                 ])
             case .faceID:
                 call.success([
-                    "value": true
+                    "value": 'FaceId'
                 ])
             }
         } else {
             call.success([
-                "value": false
+                "value": 'None'
             ])
         }
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,7 +7,7 @@ declare module '@capacitor/core' {
 
 export interface FaceIdPluginIsAvailableResult {
   /**  Returns available biometric type or 'None' if unavailable */
-  value: string;
+  value: 'None' | 'TouchId' | 'FaceId';
 }
 
 export interface FaceIdPluginAuthOptions {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -6,8 +6,7 @@ declare module '@capacitor/core' {
 }
 
 export interface FaceIdPluginIsAvailableResult {
-  /** true if Face ID or Touch ID is available */
-  value: boolean;
+  value: string;
 }
 
 export interface FaceIdPluginAuthOptions {
@@ -19,7 +18,7 @@ export interface FaceIdPlugin {
   /**
    * check if Face ID or Touch ID is available
    * @returns  {Promise}
-   * @resolve {value: boolean}
+   * @resolve {value: string}
    * @rejects PluginResultError
    */
   isAvailable(): Promise<FaceIdPluginIsAvailableResult>;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -6,6 +6,7 @@ declare module '@capacitor/core' {
 }
 
 export interface FaceIdPluginIsAvailableResult {
+  /**  Returns available biometric type or 'None' if unavailable */
   value: string;
 }
 


### PR DESCRIPTION
Taking authorization context variable out of the global context makes it so the user is prompted every time evaluatePolicy() is called, instead of succeeding automatically as it has been.